### PR TITLE
Fixing run.sh script and index computation

### DIFF
--- a/python-code/Utils/lasagne_tools.py
+++ b/python-code/Utils/lasagne_tools.py
@@ -93,7 +93,7 @@ def createXYZMapLayer(scoremap_cut_layer,
     num_scale = len(fScaleList)
     # scale_space_min changes according to scoremap_shape
     num_scale_after = scoremap_shape[4]
-    new_min_idx = (num_scale - num_scale_after) / 2
+    new_min_idx = (num_scale - num_scale_after) // 2
     scale_space_min = fScaleList[new_min_idx]
 
     if num_scale >= 2:

--- a/run.sh
+++ b/run.sh
@@ -30,6 +30,24 @@ export _LIFT_BASE_PATH="$(pwd)"
 
 _LIFT_PYTHON_CODE_PATH="${_LIFT_BASE_PATH}/python-code"
 
+_LIFT_C_CODE_PATH="${_LIFT_BASE_PATH}/c-code"
+
+# Check if cmake is installed
+_CMAKE_PATH=`which cmake`
+if [ ! -f "${_CMAKE_PATH}" ]
+then
+    echo "CMAKE is not installed!"
+    exit 
+fi
+
+# Make sure libSIFT is compiled
+if [ ! -f "${_LIFT_C_CODE_PATH}/libSIFT.so" ]
+then
+    (cd "${_LIFT_C_CODE_PATH}/build"; \
+     cmake .. && make
+    )
+fi
+
 # Test image and model settings
 _LIFT_TEST_IMG_NAME="img1"
 _LIFT_TEST_IMG="${_LIFT_BASE_PATH}/data/testimg/${_LIFT_TEST_IMG_NAME}.jpg"


### PR DESCRIPTION
The example script, run.sh compiles now libSIFT.
Fixed index computation, by using integer division.